### PR TITLE
修复了文档两处许可证标注错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@
 
 | 库 | 版本 | 用途 | 许可证 |
 |---|---|---|---|
-| ClassIsland.PluginSdk | 2.0.0.2 | ClassIsland 插件 SDK（宿主交互 / 设置页 / 服务） | MIT |
-| MaterialColorUtilities | 0.3.0 | 专辑封面取色（Material You 调色板） | MIT |
+| ClassIsland.PluginSdk | 2.0.0.2 | ClassIsland 插件 SDK（宿主交互 / 设置页 / 服务） | LGPL-3.0 |
+| MaterialColorUtilities | 0.3.0 | 专辑封面取色（Material You 调色板） | Apache-2.0 |
 | NAudio.Wasapi | 2.2.1 | 音频频谱捕获（动态频谱纹理） | MIT |
 | System.Drawing.Common | 8.0.25 | GIF 逐帧解码、屏幕抓取 | MIT |
 


### PR DESCRIPTION
## 这个 Pull request 做了
- 根据 https://github.com/ClassIsland/ClassIsland/blob/master/ClassIsland.PluginSdk/LICENSE.txt 将 ClassIsland.PluginSdk 的许可证标注修改为 LGPL-3.0；
- 根据 https://github.com/albi005/MaterialColorUtilities 将 MaterialColorUtilities 的许可证标注修改为 Apache-2.0。

## 同时提醒作者
- 暂未在仓库中发现 THIRD-PARTY-NOTICES 文件（该文件通常包含第三方组件的著作权声明及其许可证原文），或许作者希望通过在 README 文件中提及使用的第三方组件的方式来代替，建议在 README 文件的基础上添加第三方组件的原始许可证文件可能会更好一些（或者改为使用 THIRD-PARTY-NOTICES）；
- 注意到仓库中包含 hanabi 效果（ https://github.com/LingFeng-bbben/MajdataView ）的相关贴图，并且参照 MajdataView 的 Firework.prefab 和 fire.anim 等的动画数据重新实现了部分代码，鉴于 MajdataView 基于 GPL-3.0 许可证授权，本仓库的许可证（MIT）会可能受到影响。
